### PR TITLE
Pin Vercel function runtime version

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,7 @@
   },
   "functions": {
     "src/app/api/**/*.ts": {
-      "runtime": "nodejs18.x"
+      "runtime": "@vercel/node@5.3.22"
     }
   }
 }


### PR DESCRIPTION
## Summary
- update the Vercel function runtime configuration to use @vercel/node@5.3.22 for API routes so deployments target a valid runtime version

## Testing
- not run (not required for this change)


------
https://chatgpt.com/codex/tasks/task_e_68ccfe94ba64833397fe674bd9f63549