### PR TITLE
fix: improve mock service banner readability

### DIFF
--- a/src/__tests__/components/mock-service-banner.test.tsx
+++ b/src/__tests__/components/mock-service-banner.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { MockServiceBanner } from '@/components/mock-service-banner'
+
+jest.mock('@/lib/mock-config', () => ({
+  getServiceStatus: () => ({
+    database: 'connected',
+    sportsData: 'connected',
+    kyc: 'connected',
+  }),
+}))
+
+describe('MockServiceBanner', () => {
+  it('formats service names for display', async () => {
+    render(<MockServiceBanner />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Sports Data')).toBeInTheDocument()
+      expect(screen.getByText('KYC')).toBeInTheDocument()
+    })
+  })
+
+  it('exposes an accessible control to dismiss the banner', async () => {
+    render(<MockServiceBanner />)
+
+    const dismissButton = await screen.findByRole('button', {
+      name: /dismiss development mode notice/i,
+    })
+
+    expect(dismissButton).toBeInTheDocument()
+  })
+})

--- a/src/__tests__/lib/utils.test.ts
+++ b/src/__tests__/lib/utils.test.ts
@@ -1,0 +1,20 @@
+import { formatServiceName } from '@/lib/utils'
+
+describe('formatServiceName', () => {
+  it('converts camelCase keys to spaced title case', () => {
+    expect(formatServiceName('sportsData')).toBe('Sports Data')
+  })
+
+  it('uppercases short abbreviations', () => {
+    expect(formatServiceName('kyc')).toBe('KYC')
+  })
+
+  it('handles single word keys', () => {
+    expect(formatServiceName('database')).toBe('Database')
+  })
+
+  it('handles kebab and snake case inputs', () => {
+    expect(formatServiceName('feature-flags')).toBe('Feature Flags')
+    expect(formatServiceName('redis_cache')).toBe('Redis Cache')
+  })
+})

--- a/src/components/mock-service-banner.tsx
+++ b/src/components/mock-service-banner.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import { getServiceStatus } from '@/lib/mock-config'
+import { formatServiceName } from '@/lib/utils'
 import { CheckCircle, XCircle, AlertCircle, Wifi } from 'lucide-react'
 import { Card, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
@@ -61,6 +62,7 @@ export function MockServiceBanner() {
             size="sm"
             onClick={() => setIsVisible(false)}
             className="text-blue-600 hover:text-blue-800"
+            aria-label="Dismiss development mode notice"
           >
             ×
           </Button>
@@ -79,7 +81,7 @@ export function MockServiceBanner() {
                 className={`flex items-center space-x-2 rounded-md border px-2 py-1 text-xs ${getStatusColor(status)}`}
               >
                 {getStatusIcon(status)}
-                <span className="capitalize">{service.replace(/([A-Z])/g, ' $1').trim()}</span>
+                <span>{formatServiceName(service)}</span>
               </div>
             ))}
           </div>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -99,6 +99,23 @@ export function slugify(text: string): string {
     .replace(/ +/g, '-')
 }
 
+export function formatServiceName(serviceKey: string): string {
+  return serviceKey
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map(segment => {
+      const normalized = segment.toLowerCase()
+
+      if (normalized.length <= 3) {
+        return normalized.toUpperCase()
+      }
+
+      return normalized.charAt(0).toUpperCase() + normalized.slice(1)
+    })
+    .join(' ')
+}
+
 export function truncateText(text: string, maxLength: number): string {
   if (text.length <= maxLength) return text
   return text.substr(0, maxLength).trim() + '...'


### PR DESCRIPTION
## Summary
- format mock service status keys into human-friendly labels and add an accessible dismiss control
- add a reusable formatter helper for service keys
- cover the new helper and banner behaviour with focused unit tests

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de40e136888333908e72f94e5ed4c7